### PR TITLE
Updated for RN 0.0.40+

### DIFF
--- a/RNICloudUserToken.m
+++ b/RNICloudUserToken.m
@@ -5,9 +5,9 @@
 //
 //
 
-#import "RCTBridgeModule.h"
-#import "RCTEventDispatcher.h"
-#import "RCTUtils.h"
+#import "React/RCTBridgeModule.h"
+#import "React/RCTEventDispatcher.h"
+#import "React/RCTUtils.h"
 
 @import CloudKit;
 


### PR DESCRIPTION
All RCT modules need React/ namespace since version 0.0.40